### PR TITLE
feat: Disable semicolons in Zed editor settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -13,7 +13,7 @@
     // Format config
     "tabWidth": 2,
     "useTabs": false,
-    "semi": true,
+    "semi": false,
     "singleQuote": true,
     "jsxSingleQuote": true,
     "bracketSpacing": true,


### PR DESCRIPTION
Removes the use of semicolons in the Zed editor settings, as the team has decided to adopt a code style that prefers the use of single quotes over double quotes and the omission of semicolons. This change aligns the project with the preferred coding conventions.